### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# swift
+[*.swift]
+indent_style = space
+indent_size = 2
+
+# documentation, utils
+[*.{md,mdx,diff}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This way anyone contributing to the repo will have the same indentation settings that you have. Automatically!

This is [a new feature in Xcode 16](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#Source-Editor). You can read more about `.editorconfig` files [here](https://editorconfig.org).