### PR TITLE
Fix SDFCore module not found

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .visionOS(.v1),
   ],
   products: [
-    .executable(name: "safedi-formatter", targets: ["SDFCore"]),
+    .executable(name: "safedi-formatter", targets: ["CLI"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
@@ -22,9 +22,16 @@ let package = Package(
   ],
   targets: [
     .executableTarget(
+      name: "CLI",
+      dependencies: [
+        "SDFCore",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ],
+      swiftSettings: [.swiftLanguageMode(.v6)]
+    ),
+    .target(
       name: "SDFCore",
       dependencies: [
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ],

--- a/Sources/CLI/SortInitializerCommand.swift
+++ b/Sources/CLI/SortInitializerCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import SDFCore
 import Foundation
 
 @main

--- a/Sources/SDFCore/Helpers/FileManager+SwiftFiles.swift
+++ b/Sources/SDFCore/Helpers/FileManager+SwiftFiles.swift
@@ -7,7 +7,7 @@ extension FileManager {
   ///
   /// - Parameter baseURL: The URL to look for Swift files. It can either be a file or a directory
   /// - Returns: All the files with a .swift extension at the given URL or an empty array if none exist
-  func swiftFiles(at baseURL: URL) -> [URL] {
+  public func swiftFiles(at baseURL: URL) -> [URL] {
     guard baseURL.hasDirectoryPath else {
       return baseURL.pathExtension == "swift" ? [baseURL] : []
     }
@@ -36,7 +36,7 @@ extension FileManager {
   ///
   /// - Parameter baseURL: The URL to look for a Swift file
   /// - Returns: `true` if the URL contains a Swift file, `false` otherwise
-  func isSwiftFile(at baseURL: URL) -> Bool {
+  public func isSwiftFile(at baseURL: URL) -> Bool {
     FileManager.default.fileExists(atPath: baseURL.path) && !baseURL.hasDirectoryPath && baseURL.pathExtension == "swift"
   }
 }

--- a/Sources/SDFCore/MacroInitializerSorter.swift
+++ b/Sources/SDFCore/MacroInitializerSorter.swift
@@ -3,10 +3,10 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftParser
 
-struct MacroInitializerSorter {
-  let macroName: String
+public struct MacroInitializerSorter {
+  private let macroName: String
   
-  init(macroName: String) {
+  public init(macroName: String) {
     self.macroName = macroName
   }
   
@@ -15,7 +15,7 @@ struct MacroInitializerSorter {
   /// - Parameter fileURL: The path to the Swift file
   /// - Returns: A source accurate description of the Swift file at the fileURL
   @discardableResult
-  func run(on fileURL: URL) async throws -> String {
+  public func run(on fileURL: URL) async throws -> String {
     // TODO: Potentially optimize performance by discarding Swift files that do not use the macro.
     
     let original = try String(contentsOfFile: fileURL.path, encoding: .utf8)


### PR DESCRIPTION
I've known [executable targets have a problem when running unit tests](https://forums.swift.org/t/unit-testing-executable-targets-with-swift-package-manager/44860/5) on them, but since I haven't tried it in a couple of years I decided to give it another try with this package.

Even though things worked out locally and using the CLI, it started failing for @dfed when he pulled the repo, and after pulling the latest version the same happened to me.

To be safe, I created a new CLI target that contains the parsing of the arguments and delegates the rest to the SDFCore target for uni testing.