### PR TITLE
Add sorting of the assignment of properties inside of an initializer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,11 +14,13 @@ let package = Package(
     .visionOS(.v1),
   ],
   products: [
-    .executable(name: "safedi-formatter", targets: ["CLI"]),
+    .executable(name: "safedi-formatter", targets: ["CLI"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
+    .package(
+      url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+    .package(
+      url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
   ],
   targets: [
     .executableTarget(
@@ -33,7 +35,7 @@ let package = Package(
       name: "SDFCore",
       dependencies: [
         .product(name: "SwiftSyntax", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftOperators", package: "swift-syntax"),
       ],
       swiftSettings: [.swiftLanguageMode(.v6)]
     ),
@@ -41,6 +43,6 @@ let package = Package(
       name: "SDFCoreTests",
       dependencies: ["SDFCore"],
       swiftSettings: [.swiftLanguageMode(.v6)]
-    )
+    ),
   ]
 )

--- a/Sources/CLI/SortInitializerCommand.swift
+++ b/Sources/CLI/SortInitializerCommand.swift
@@ -1,30 +1,30 @@
 import ArgumentParser
-import SDFCore
 import Foundation
+import SDFCore
 
 @main
 public struct SortInitializerCommand: AsyncParsableCommand {
   public init() {}
-  
+
   public static let configuration = CommandConfiguration(
     commandName: "sort",
     abstract: "Sorts the initializers of the provided macro alphabetically")
-  
+
   @Option(help: "The name of the macro to sort.")
   var macro: String = "Instantiable"
-  
+
   @Argument(
     help: "The path to a Swift file or directory containing Swift files",
     transform: URL.init(fileURLWithPath:))
   var path: URL
-  
+
   public mutating func run() async throws {
     let swiftFiles = FileManager.default.swiftFiles(at: path)
-    
+
     guard !swiftFiles.isEmpty else {
       throw CleanExit.message("No .swift files found at \(path.path). Exiting.")
     }
-    
+
     for file in swiftFiles {
       let sorter = MacroInitializerSorter(macroName: macro)
       try await sorter.run(on: file)

--- a/Sources/SDFCore/Helpers/FileManager+SwiftFiles.swift
+++ b/Sources/SDFCore/Helpers/FileManager+SwiftFiles.swift
@@ -14,13 +14,13 @@ extension FileManager {
 
     var swiftFiles: [URL] = []
 
-    guard let enumerator = self.enumerator(
-      at: baseURL,
-      includingPropertiesForKeys: nil,
-      options: [.skipsHiddenFiles])
-      else
-    {
-      return  []
+    guard
+      let enumerator = self.enumerator(
+        at: baseURL,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles])
+    else {
+      return []
     }
 
     for case let fileURL as URL in enumerator {
@@ -37,6 +37,7 @@ extension FileManager {
   /// - Parameter baseURL: The URL to look for a Swift file
   /// - Returns: `true` if the URL contains a Swift file, `false` otherwise
   public func isSwiftFile(at baseURL: URL) -> Bool {
-    FileManager.default.fileExists(atPath: baseURL.path) && !baseURL.hasDirectoryPath && baseURL.pathExtension == "swift"
+    FileManager.default.fileExists(atPath: baseURL.path) && !baseURL.hasDirectoryPath
+      && baseURL.pathExtension == "swift"
   }
 }

--- a/Sources/SDFCore/MacroInitializerRewriter.swift
+++ b/Sources/SDFCore/MacroInitializerRewriter.swift
@@ -138,7 +138,7 @@ private final class MacroInitializerRewriter: SyntaxRewriter {
     let opPrecedence = OperatorTable.standardOperators
 
     for statement in body.statements {
-      
+
       let assignment: Assignment
       // Group statements of the type `self.a = a` - i.e. self assignments where the property name is equal on both sides
       if let item = SequenceExprSyntax(statement.item),

--- a/Sources/SDFCore/MacroInitializerRewriter.swift
+++ b/Sources/SDFCore/MacroInitializerRewriter.swift
@@ -1,3 +1,4 @@
+import SwiftOperators
 import SwiftSyntax
 
 /// Filters the nodes to visit. It only visits structures that have the provided macro, ignores all others.
@@ -7,7 +8,7 @@ final class MacroFilteringRewriter: SyntaxRewriter {
   init(macroName: String) {
     self.rewriter = MacroInitializerRewriter(macroName: macroName)
   }
-  
+
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
     guard node.attributes.hasMacroNamed(rewriter.macroName) else {
       return super.visit(node)
@@ -21,7 +22,7 @@ final class MacroFilteringRewriter: SyntaxRewriter {
     }
     return rewriter.visit(node)
   }
-  
+
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
     guard node.attributes.hasMacroNamed(rewriter.macroName) else {
       return super.visit(node)
@@ -30,40 +31,46 @@ final class MacroFilteringRewriter: SyntaxRewriter {
   }
 }
 
-fileprivate extension AttributeListSyntax {
+extension AttributeListSyntax {
   /// Finds if the attribute list contains an macro with a given name
   /// - Parameter macroName: The name of the macro
   /// - Returns: True if the macro name was being used. False otherwise
-  func hasMacroNamed(_ macroName: String) -> Bool {
+  fileprivate func hasMacroNamed(_ macroName: String) -> Bool {
     return contains { attribute in
       guard
         let attributeNode = attribute.as(AttributeSyntax.self),
-        let attributeNameSyntax = attributeNode.attributeName.as(IdentifierTypeSyntax.self)
+        let attributeNameSyntax = attributeNode.attributeName.as(
+          IdentifierTypeSyntax.self)
       else {
         return false
       }
-      
+
       return attributeNameSyntax.name.text == macroName
     }
   }
 }
 
 /// Sorts the initializers
-fileprivate final class MacroInitializerRewriter: SyntaxRewriter {
+private final class MacroInitializerRewriter: SyntaxRewriter {
   fileprivate let macroName: String
   private var typeDeclsEncountered = 0
 
   init(macroName: String) {
     self.macroName = macroName
   }
-  
+
   override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
     guard typeDeclsEncountered == 1 else {
       return super.visit(node)
     }
-    
-    let initializerNode = sortParameters(node)
-    return DeclSyntax(initializerNode)
+
+    let updatedInitializerNode = sortParameters(node)
+    guard let body = updatedInitializerNode.body else {
+      return DeclSyntax(updatedInitializerNode)
+    }
+
+    let updatedBody = sortBodyAssignment(body)
+    return DeclSyntax(updatedInitializerNode.with(\.body, updatedBody))
   }
 
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
@@ -82,30 +89,73 @@ fileprivate final class MacroInitializerRewriter: SyntaxRewriter {
   }
 
   override func visitPost(_ node: Syntax) {
-    if StructDeclSyntax(node) != nil || ActorDeclSyntax(node) != nil || ClassDeclSyntax(node) != nil {
+    if StructDeclSyntax(node) != nil || ActorDeclSyntax(node) != nil
+      || ClassDeclSyntax(node) != nil
+    {
       typeDeclsEncountered -= 1
     }
     super.visitPost(node)
   }
-  
-  private func sortParameters(_ node: InitializerDeclSyntax) -> InitializerDeclSyntax{
-    typealias OrderedTrivia = (leadingTrivia: Trivia, trailingComma: TokenSyntax?)
-    let originalParameterMetatada: [OrderedTrivia] = node.signature.parameterClause.parameters.map { ($0.leadingTrivia, $0.trailingComma) }
-    
+
+  private func sortParameters(_ node: InitializerDeclSyntax)
+    -> InitializerDeclSyntax
+  {
+    typealias OrderedTrivia = (
+      leadingTrivia: Trivia, trailingComma: TokenSyntax?
+    )
+    let originalParameterMetatada: [OrderedTrivia] = node.signature
+      .parameterClause.parameters.map { ($0.leadingTrivia, $0.trailingComma) }
+
     let sortedParameters = node.signature.parameterClause.parameters.sorted {
       $0.firstName.text < $1.firstName.text
     }.enumerated().map { index, element in
       let original = originalParameterMetatada[index]
-      return element
+      return
+        element
         .with(\.leadingTrivia, original.leadingTrivia)
         .with(\.trailingComma, original.trailingComma)
     }
-    
+
     // Rewrite the nodes
-    let functionParameterListNode = FunctionParameterListSyntax(sortedParameters)
-    let parameterClauseNode = node.signature.parameterClause.with(\.parameters, functionParameterListNode)
-    let signatureNode = node.signature.with(\.parameterClause, parameterClauseNode)
-    
+    let functionParameterListNode = FunctionParameterListSyntax(
+      sortedParameters)
+    let parameterClauseNode = node.signature.parameterClause.with(
+      \.parameters, functionParameterListNode)
+    let signatureNode = node.signature.with(
+      \.parameterClause, parameterClauseNode)
+
     return node.with(\.signature, signatureNode)
+  }
+
+  private func sortBodyAssignment(_ body: CodeBlockSyntax) -> CodeBlockSyntax {
+    typealias Assignment = (leftOperand: String, item: CodeBlockItemSyntax)
+    var assignments: [Assignment] = []
+    var otherStatements: [CodeBlockItemSyntax] = []
+
+    // We need to fold the operators to get better information about the SequenceExpr node.  https://github.com/swiftlang/swift-syntax/blob/df28b99b5942bcf78b337bd15eafd8c80508d258/Sources/SwiftOperators/SwiftOperators.docc/SwiftOperators.md#quickstart
+    let opPrecedence = OperatorTable.standardOperators
+
+    for statement in body.statements {
+      // Group all statements that start with `self.` in an array
+      if let item = SequenceExprSyntax(statement.item),
+        let foldedNode = try? opPrecedence.foldSingle(item),
+        let infixOperand = InfixOperatorExprSyntax(foldedNode),
+        infixOperand.leftOperand.trimmed.description.starts(with: "self.")
+      {
+        assignments.append(
+          Assignment(infixOperand.leftOperand.description, statement))
+      } else {
+        otherStatements.append(statement)
+      }
+    }
+
+    let sortedStatements: [CodeBlockItemSyntax] =
+      assignments
+      .sorted { $0.leftOperand < $1.leftOperand }
+      .map { $0.item }
+
+    let codeBlockListSyntax = CodeBlockItemListSyntax(
+      sortedStatements + otherStatements)
+    return body.with(\.statements, codeBlockListSyntax)
   }
 }

--- a/Sources/SDFCore/MacroInitializerRewriter.swift
+++ b/Sources/SDFCore/MacroInitializerRewriter.swift
@@ -140,7 +140,7 @@ private final class MacroInitializerRewriter: SyntaxRewriter {
     for statement in body.statements {
       
       let assignment: Assignment
-      // Group all statements that start with `self.` in an array
+      // Group statements of the type `self.a = a` - i.e. self assignments where the property name is equal on both sides
       if let item = SequenceExprSyntax(statement.item),
         let foldedNode = try? opPrecedence.foldSingle(item),
         let infixOperand = InfixOperatorExprSyntax(foldedNode),
@@ -180,8 +180,12 @@ private struct GroupedAssignments {
     default:
       let currentArray: [Assignment]
       if lastInsertedType == assignment.group {
+        // Since we're already in the same group, we can grab the last array of the "assignments" property
+        // and simply append a new element to it.
         currentArray = assignments.removeLast() + [assignment]
       } else {
+        // Since the previous inserted element is of a different group type, we need to split it into
+        // its own array for sorting purposes.
         currentArray = [assignment]
       }
 

--- a/Sources/SDFCore/MacroInitializerSorter.swift
+++ b/Sources/SDFCore/MacroInitializerSorter.swift
@@ -1,14 +1,14 @@
 import Foundation
-import SwiftSyntax
 import SwiftParser
+import SwiftSyntax
 
 public struct MacroInitializerSorter {
   private let macroName: String
-  
+
   public init(macroName: String) {
     self.macroName = macroName
   }
-  
+
   ///  Runs the sorter on the provided Swift file, sorting the initializer parameters alphabetically
   ///
   /// - Parameter fileURL: The path to the Swift file
@@ -16,17 +16,17 @@ public struct MacroInitializerSorter {
   @discardableResult
   public func run(on fileURL: URL) async throws -> String {
     // TODO: Potentially optimize performance by discarding Swift files that do not use the macro.
-    
+
     let original = try String(contentsOfFile: fileURL.path, encoding: .utf8)
     let updated = try await run(onContent: original)
-    
-    guard original != updated else { return  original }
-    
+
+    guard original != updated else { return original }
+
     try updated.write(to: fileURL, atomically: false, encoding: .utf8)
     return updated
-    
+
   }
-  
+
   @discardableResult
   func run(onContent content: String) async throws -> String {
     let sourceFile = Parser.parse(source: content)

--- a/Sources/SDFCore/MacroInitializerSorter.swift
+++ b/Sources/SDFCore/MacroInitializerSorter.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftSyntax
-import SwiftSyntaxBuilder
 import SwiftParser
 
 public struct MacroInitializerSorter {

--- a/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
+++ b/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
@@ -1,201 +1,290 @@
 import Foundation
 import Testing
+
 @testable import SDFCore
 
 final class MacroInitializerSorterTests {
-  let sut = MacroInitializerSorter(macroName: "TestMacro")
+  struct PropertiesTests {
+    let sut = MacroInitializerSorter(macroName: "TestMacro")
 
-  @Test(
-    "With an initializer without the macro, it does not modify the source",
-    arguments: TestData.NoMacro.allCases)
-  func run_doesNotSort(content: TestData.NoMacro) async throws {
-    try await #expect(sut.run(onContent: content.rawValue) == content.rawValue)
+    @Test(
+      "With an initializer without the macro, it does not modify the source",
+      arguments: TestData.NoMacro.allCases)
+    func run_doesNotSort(content: TestData.NoMacro) async throws {
+      try await #expect(
+        sut.run(onContent: content.rawValue) == content.rawValue)
+    }
+
+    @Test(
+      "With a type that uses the macro, it sorts the init parameters",
+      arguments: TestData.WithMacro.allCases)
+    func run_doesSort(content: TestData.WithMacro) async throws {
+      try await #expect(
+        sut.run(onContent: content.rawValue).contains("init(a: Int, b: String"))
+    }
+
+    @Test(
+      "With a type that uses the macro and has a multi line initializer. It sorts the init parameters",
+      arguments: TestData.WithMacroMultiline.allCases)
+    func run_doesSortMultiLine(content: TestData.WithMacroMultiline)
+      async throws
+    {
+      let expected = """
+          init(a: Int, 
+               b: String) {}
+        """
+      try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    }
+
+    @Test(
+      "With a type that uses the macro that defines a nested type with an unsorted initializer. It sorts the outer init parameters",
+      arguments: TestData.WithNestedDefinitions.allCases)
+    func run_doesSortOuterWhenNestedPresent(
+      content: TestData.WithNestedDefinitions
+    ) async throws {
+      let expected = """
+          init(a: Int, 
+               b: String) {}
+        """
+      try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    }
+
+    @Test(
+      "With a type that uses the macro that defines a nested type with an unsorted initializer. It does not sort the nested init parameters",
+      arguments: TestData.WithNestedDefinitions.allCases)
+    func run_doesNotSortNested(content: TestData.WithNestedDefinitions)
+      async throws
+    {
+      let expected = """
+            init(d: String,
+                 c: Int) {}
+        """
+      try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    }
+
+    @Test(
+      "With a type that uses the macro inside of another type. It sorts the inner init parameters",
+      arguments: TestData.WithNestedDefinitionMacroInside.allCases)
+    func run_doesSortInnerWhenNested(
+      content: TestData.WithNestedDefinitionMacroInside
+    ) async throws {
+      let expected = "    init(c: Int, d: String) {}"
+      try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    }
+
+    @Test(
+      "With a type that uses the macro inside of another type. It does not sort the outer init parameters",
+      arguments: TestData.WithNestedDefinitionMacroInside.allCases)
+    func run_doesNotSortOuterNested(
+      content: TestData.WithNestedDefinitionMacroInside
+    ) async throws {
+      let expected = "  init(b: String, a: Int) {}"
+      try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    }
+
   }
 
-  @Test(
-    "With a type that uses the macro, it sorts the init parameters",
-    arguments: TestData.WithMacro.allCases)
-  func run_doesSort(content: TestData.WithMacro) async throws {
-    try await #expect(sut.run(onContent: content.rawValue).contains("init(a: Int, b: String"))
-  }
+  struct AssignmentTests {
+    let sut = MacroInitializerSorter(macroName: "TestMacro")
 
-  @Test(
-    "With a type that uses the macro and has a multi line initializer. It sorts the init parameters",
-    arguments: TestData.WithMacroMultiline.allCases)
-  func run_doesSortMultiLine(content: TestData.WithMacroMultiline) async throws {
-    let expected = """
-      init(a: Int, 
-           b: String) {}
-    """
-    try await #expect(sut.run(onContent: content.rawValue).contains(expected))
-  }
+    @Test(
+      "With a self assignments in the intitializer. It sorts them",
+      arguments: TestData.types
+    )
+    func run_sortsAssignments(type: String) async throws {
+      let content = """
+        @TestMacro
+        \(type) Some {
+          init(a: Int, b: String) {
+            self.b = b
+            self.a = a
+          }
+        }
+        """
+      let expected = """
+            self.a = a
+            self.b = b
+        """
+      #expect(try await sut.run(onContent: content).contains(expected))
+    }
 
-  @Test(
-    "With a type that uses the macro that defines a nested type with an unsorted initializer. It sorts the outer init parameters",
-    arguments: TestData.WithNestedDefinitions.allCases)
-  func run_doesSortOuterWhenNestedPresent(content: TestData.WithNestedDefinitions) async throws {
-    let expected = """
-      init(a: Int, 
-           b: String) {}
-    """
-    try await #expect(sut.run(onContent: content.rawValue).contains(expected))
-  }
+    @Test(
+      "With self assignments and other values in the intitializer. It sorts them with all the self assignments on top",
+      arguments: TestData.types
+    )
+    func run_sortsAssignmentsWithOther(type: String) async throws {
+      let content = """
+        @TestMacro
+        \(type) Some {
+          init(a: Int) {
+            b = Type()
+            self.a = a
+          }
+        }
+        """
+      let expected = """
+            self.a = a
+            b = Type()
+        """
+      #expect(try await sut.run(onContent: content).contains(expected))
+    }
 
-  @Test(
-    "With a type that uses the macro that defines a nested type with an unsorted initializer. It does not sort the nested init parameters",
-    arguments: TestData.WithNestedDefinitions.allCases)
-  func run_doesNotSortNested(content: TestData.WithNestedDefinitions) async throws {
-    let expected = """
-        init(d: String,
-             c: Int) {}
-    """
-    try await #expect(sut.run(onContent: content.rawValue).contains(expected))
-  }
-  
-  @Test(
-    "With a type that uses the macro inside of another type. It sorts the inner init parameters",
-    arguments: TestData.WithNestedDefinitionMacroInside.allCases)
-  func run_doesSortInnerWhenNested(content: TestData.WithNestedDefinitionMacroInside) async throws {
-    let expected = "    init(c: Int, d: String) {}"
-    try await #expect(sut.run(onContent: content.rawValue).contains(expected))
-  }
-  
-  @Test(
-    "With a type that uses the macro inside of another type. It does not sort the outer init parameters",
-    arguments: TestData.WithNestedDefinitionMacroInside.allCases)
-  func run_doesNotSortOuterNested(content: TestData.WithNestedDefinitionMacroInside) async throws {
-    let expected = "  init(b: String, a: Int) {}"
-    try await #expect(sut.run(onContent: content.rawValue).contains(expected))
+    @Test(
+      "With self assignments and block statements in the intitializer. It sorts them with all the self assignments on top",
+      arguments: TestData.types
+    )
+    func run_sortsAssignmentsWithBlockStatements(type: String) async throws {
+      let content = """
+        @TestMacro
+        \(type) Some {
+          init(a: Int) {
+            b = Type { some in
+              some.doSomething()
+            }
+            self.a = a
+          }
+        }
+        """
+      let expected = """
+            self.a = a
+            b = Type { some in
+              some.doSomething()
+            }
+        """
+      #expect(try await sut.run(onContent: content).contains(expected))
+    }
   }
 }
 
 struct TestData {
+  static let types: [String] = ["actor", "class", "struct"]
+
   enum NoMacro: String, CaseIterable {
     case actorContent = """
-    actor Some {
-      init(b: String, a: Int) {}
-    }
-    """
-    case classContent = """
-    class Some {
-      init(b: String, a: Int) {}
-    }
-    """
-    case structContent = """
-      struct Some {
+      actor Some {
         init(b: String, a: Int) {}
       }
-    """
+      """
+    case classContent = """
+      class Some {
+        init(b: String, a: Int) {}
+      }
+      """
+    case structContent = """
+        struct Some {
+          init(b: String, a: Int) {}
+        }
+      """
   }
-  
+
   enum WithMacro: String, CaseIterable {
     case actorContent = """
-    @TestMacro
-    actor Some {
-      init(b: String, a: Int) {}
-    }
-    """
-    case classContent = """
-    @TestMacro
-    class Some {
-      init(b: String, a: Int) {}
-    }
-    """
-    case structContent = """
-    @TestMacro
-      struct Some {
+      @TestMacro
+      actor Some {
         init(b: String, a: Int) {}
       }
-    """
+      """
+    case classContent = """
+      @TestMacro
+      class Some {
+        init(b: String, a: Int) {}
+      }
+      """
+    case structContent = """
+      @TestMacro
+        struct Some {
+          init(b: String, a: Int) {}
+        }
+      """
   }
-  
+
   enum WithMacroMultiline: String, CaseIterable {
     case actorContent = """
-    @TestMacro
-    actor Some {
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      @TestMacro
+      actor Some {
+        init(b: String, 
+             a: Int) {}
+      }
+      """
     case classContent = """
-    @TestMacro
-    class Some {
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      @TestMacro
+      class Some {
+        init(b: String, 
+             a: Int) {}
+      }
+      """
     case structContent = """
-    @TestMacro
-    struct Some {
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      @TestMacro
+      struct Some {
+        init(b: String, 
+             a: Int) {}
+      }
+      """
   }
 
   enum WithNestedDefinitions: String, CaseIterable {
     case actorContent = """
-    @TestMacro
-    actor Outer {
-      actor Some {
-        init(d: String,
-             c: Int) {}
+      @TestMacro
+      actor Outer {
+        actor Some {
+          init(d: String,
+               c: Int) {}
+        }
+        init(b: String, 
+             a: Int) {}
       }
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      """
     case classContent = """
-    @TestMacro
-    class Outer {
-      class Some {
-        init(d: String,
-             c: Int) {}
+      @TestMacro
+      class Outer {
+        class Some {
+          init(d: String,
+               c: Int) {}
+        }
+        init(b: String, 
+             a: Int) {}
       }
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      """
     case structContent = """
-    @TestMacro
-    struct Outer {
-      struct Some {
-        init(d: String,
-             c: Int) {}
+      @TestMacro
+      struct Outer {
+        struct Some {
+          init(d: String,
+               c: Int) {}
+        }
+        init(b: String, 
+             a: Int) {}
       }
-      init(b: String, 
-           a: Int) {}
-    }
-    """
+      """
   }
-  
+
   enum WithNestedDefinitionMacroInside: String, CaseIterable {
     case actorContent = """
-    actor Outer {
-      @TestMacro
-      actor Inner {
-        init(d: String, c: Int) {}
+      actor Outer {
+        @TestMacro
+        actor Inner {
+          init(d: String, c: Int) {}
+        }
+        init(b: String, a: Int) {}
       }
-      init(b: String, a: Int) {}
-    }
-    """
+      """
     case classContent = """
-    class Outer {
-      @TestMacro
-      class Inner {
-        init(d: String, c: Int) {}
+      class Outer {
+        @TestMacro
+        class Inner {
+          init(d: String, c: Int) {}
+        }
+        init(b: String, a: Int) {}
       }
-      init(b: String, a: Int) {}
-    }
-    """
+      """
     case structContent = """
-    struct Outer {
-      @TestMacro
-      struct Inner {
-        init(d: String, c: Int) {}
+      struct Outer {
+        @TestMacro
+        struct Inner {
+          init(d: String, c: Int) {}
+        }
+        init(b: String, a: Int) {}
       }
-      init(b: String, a: Int) {}
-    }
-    """
+      """
   }
 }

--- a/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
+++ b/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
@@ -248,6 +248,31 @@ final class MacroInitializerSorterTests {
       let real = try await sut.run(onContent: content)
       #expect(real.contains(expected))
     }
+    
+    @Test(
+      "With self assignments that are not of type self.a = a. It does not sort them.",
+      arguments: TestData.types
+    )
+    func run_sortsAssignments_withOtherSelfAssignments_itDoesNotSortThem(type: String) async throws {
+      let content = """
+        @TestMacro
+        \(type) Some {
+          init(b: Int, c: Int) {
+            self.c = c
+            self.b = b
+            self.a = Type()
+          }
+        }
+        """
+      let expected = """
+            self.b = b
+            self.c = c
+            self.a = Type()
+        """
+
+      let real = try await sut.run(onContent: content)
+      #expect(real.contains(expected))
+    }
   }
 }
 

--- a/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
+++ b/Tests/SDFCoreTests/MacroInitializerSorterTests.swift
@@ -248,12 +248,13 @@ final class MacroInitializerSorterTests {
       let real = try await sut.run(onContent: content)
       #expect(real.contains(expected))
     }
-    
+
     @Test(
       "With self assignments that are not of type self.a = a. It does not sort them.",
       arguments: TestData.types
     )
-    func run_sortsAssignments_withOtherSelfAssignments_itDoesNotSortThem(type: String) async throws {
+    func run_sortsAssignments_withOtherSelfAssignments_itDoesNotSortThem(type: String) async throws
+    {
       let content = """
         @TestMacro
         \(type) Some {


### PR DESCRIPTION
This PR adds the second part of this formatter, i.e. sorting the initializer block where all the properties are being assigned.

If you think of another test case I haven't considered please lmk and I'll add it.

**I'd highly recommend checking the "Hide whitespace" checkbox to review this PR**


<img width="574" alt="Screenshot 2024-11-13 at 14 22 09" src="https://github.com/user-attachments/assets/4f6e6059-27d5-4f9f-8a48-ab69f08dff80">



